### PR TITLE
[codex] add renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":configMigration",
+    ":maintainLockFilesWeekly"
+  ],
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "enabledManagers": ["cargo", "github-actions", "npm"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "packageRules": [
+    {
+      "description": "Keep example workspace app updates together.",
+      "matchManagers": ["npm"],
+      "matchFileNames": ["example/package.json", "example/**/package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "example app dependencies"
+    },
+    {
+      "description": "Keep Rust dependency updates together.",
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "rust dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- Added a repo-level Renovate configuration.
- Enabled npm/pnpm, Cargo, and GitHub Actions updates.
- Kept weekly lockfile maintenance enabled.
- Grouped minor/patch updates for example app dependencies and Rust dependencies.

## Why

This gives the repo automated dependency update PRs while keeping common update batches reviewable.

## Validation

- `jq . renovate.json >/dev/null`
- `pnpm dlx --package renovate renovate-config-validator renovate.json`
- `pnpm build` *(required `pnpm install --no-frozen-lockfile` locally because the existing lockfile is stale for example rsbuild deps; generated lockfile changes were left out of this PR)*
