### PR TITLE
[codex] Support Windows custom protocol URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ tauri::Builder::default()
 
 ## Behavior
 
-- Remote entry URLs are rewritten from `http(s)://...` to `module-federation://.../?fullUrl=...`.
+- Remote entry URLs are rewritten from `http(s)://...` to a Tauri custom-protocol URL.
+- On macOS, iOS, and Linux, the runtime package uses `module-federation://...`.
+- On Windows and Android, Tauri serves custom protocols as `http://module-federation.localhost/...`, so the runtime package uses that URL shape instead.
 - The Tauri plugin fetches those assets over the network and stores them in the app cache dir.
 - Cache keys are derived from the remote host and request path.
 - If a later fetch fails, the cached asset is served instead.

--- a/packages/tauri-plugin/src/lib.rs
+++ b/packages/tauri-plugin/src/lib.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Mutex};
 
 use sha::utils::{Digest, DigestExt};
 use tauri::{
-    http::uri,
+    http::{uri, Uri},
     plugin::{Builder, TauriPlugin},
     Manager, Runtime,
 };
@@ -39,6 +39,90 @@ impl<R: Runtime, T: Manager<R>> crate::TauriPluginModuleFederationExt<R> for T {
 #[derive(Default)]
 struct Schemes(pub Mutex<HashMap<(String, Option<u16>), String>>);
 
+fn remote_key(url: &Url) -> (String, Option<u16>) {
+    (url.host().unwrap().to_string(), url.port())
+}
+
+fn authority_from_host_port(host: &str, port: Option<u16>) -> String {
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+
+    match port {
+        Some(port) => format!("{host}:{port}"),
+        None => host,
+    }
+}
+
+fn windows_remote_path(uri: &Uri) -> Option<(String, Option<u16>, String)> {
+    if uri.host() != Some("module-federation.localhost") {
+        return None;
+    }
+
+    let path = uri.path().strip_prefix('/')?;
+    let (authority, remote_path) = path.split_once('/').unwrap_or((path, ""));
+
+    if authority.is_empty() {
+        return None;
+    }
+
+    let remote_authority = Url::parse(&format!("http://{authority}/")).ok()?;
+    let host = remote_authority.host_str()?.to_string();
+    let port = remote_authority.port();
+    let mut path_and_query = format!("/{remote_path}");
+
+    if let Some(query) = uri.query() {
+        path_and_query.push('?');
+        path_and_query.push_str(query);
+    }
+
+    Some((host, port, path_and_query))
+}
+
+fn resolve_remote_url(uri: &Uri, schemes: &Schemes) -> Url {
+    uri.query()
+        .and_then(|query| {
+            let query_pairs: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
+
+            query_pairs.get("fullUrl").map(|v| {
+                let url = Url::parse(v).unwrap();
+                let mut schemes = schemes.0.lock().unwrap();
+
+                schemes
+                    .entry(remote_key(&url))
+                    .or_insert(url.scheme().to_string());
+
+                url
+            })
+        })
+        .unwrap_or_else(|| {
+            let (host, port, path_and_query) = windows_remote_path(uri).unwrap_or_else(|| {
+                (
+                    uri.host().unwrap().to_string(),
+                    uri.port().map(|p| p.as_u16()),
+                    uri.path_and_query()
+                        .map(|p| p.as_str().to_string())
+                        .unwrap_or_else(|| "/".to_string()),
+                )
+            });
+
+            let schemes = schemes.0.lock().unwrap();
+            let scheme = schemes.get(&(host.clone(), port)).unwrap_or_else(|| {
+                dbg!(&schemes);
+                panic!("Unknown scheme for host '{host}:{port:?}'")
+            });
+
+            let builder = uri::Builder::new()
+                .scheme(scheme.as_str())
+                .authority(authority_from_host_port(&host, port))
+                .path_and_query(path_and_query);
+
+            Url::parse(&builder.build().unwrap().to_string()).unwrap()
+        })
+}
+
 /// Initializes the plugin.
 pub fn init<R: Runtime>(arg: Option<&'static str>) -> TauriPlugin<R> {
     let builder = Builder::new("tauri-plugin-module-federation")
@@ -63,42 +147,7 @@ pub fn init<R: Runtime>(arg: Option<&'static str>) -> TauriPlugin<R> {
 
                     let client = reqwest::Client::new();
                     let url = request.uri().clone();
-
-                    let url: Url = url
-                        .query()
-                        .and_then(|query| {
-                            let query_pairs: HashMap<_, _> =
-                                form_urlencoded::parse(query.as_bytes())
-                                    .into_iter()
-                                    .collect();
-
-                            query_pairs.get("fullUrl").map(|v| {
-                                let url = Url::parse(v).unwrap();
-
-                                let mut schemes = schemes.0.lock().unwrap();
-
-                                let key = (url.host().unwrap().to_string(), url.port());
-
-                                schemes.entry(key).or_insert(url.scheme().to_string());
-
-                                url
-                            })
-                        })
-                        .unwrap_or_else(|| {
-                            let url = url.clone();
-
-                            let host = url.host().unwrap().to_string();
-                            let schemes = schemes.0.lock().unwrap();
-                            let scheme = schemes
-                                .get(&(host.clone(), url.port().map(|p| p.as_u16())))
-                                .unwrap_or_else(|| {
-                                    dbg!(&schemes);
-                                    panic!("Unknown scheme for host '{host}:{:?}'", url.port())
-                                });
-
-                            let builder = uri::Builder::from(url).scheme(scheme.as_str());
-                            Url::parse(&builder.build().unwrap().to_string()).unwrap()
-                        });
+                    let url = resolve_remote_url(&url, schemes.inner());
 
                     let request_builder = client.request(request.method().clone(), url.clone());
 
@@ -186,4 +235,64 @@ pub fn init<R: Runtime>(arg: Option<&'static str>) -> TauriPlugin<R> {
             Ok(())
         })
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schemes_with_remote() -> Schemes {
+        let schemes = Schemes::default();
+        schemes
+            .0
+            .lock()
+            .unwrap()
+            .insert(("localhost".to_string(), Some(3002)), "http".to_string());
+        schemes
+    }
+
+    #[test]
+    fn resolves_entry_from_full_url_query() {
+        let schemes = Schemes::default();
+        let uri = "module-federation://localhost:3002/remoteEntry.js?fullUrl=http%3A%2F%2Flocalhost%3A3002%2FremoteEntry.js"
+            .parse()
+            .unwrap();
+
+        let url = resolve_remote_url(&uri, &schemes);
+
+        assert_eq!(url.as_str(), "http://localhost:3002/remoteEntry.js");
+        assert_eq!(
+            schemes
+                .0
+                .lock()
+                .unwrap()
+                .get(&("localhost".to_string(), Some(3002)))
+                .map(String::as_str),
+            Some("http")
+        );
+    }
+
+    #[test]
+    fn resolves_relative_asset_from_custom_scheme_url() {
+        let schemes = schemes_with_remote();
+        let uri = "module-federation://localhost:3002/static/js/chunk.js?v=1"
+            .parse()
+            .unwrap();
+
+        let url = resolve_remote_url(&uri, &schemes);
+
+        assert_eq!(url.as_str(), "http://localhost:3002/static/js/chunk.js?v=1");
+    }
+
+    #[test]
+    fn resolves_relative_asset_from_windows_protocol_url() {
+        let schemes = schemes_with_remote();
+        let uri = "http://module-federation.localhost/localhost:3002/static/js/chunk.js?v=1"
+            .parse()
+            .unwrap();
+
+        let url = resolve_remote_url(&uri, &schemes);
+
+        assert_eq!(url.as_str(), "http://localhost:3002/static/js/chunk.js?v=1");
+    }
 }

--- a/packages/tauri-plugin/src/lib.rs
+++ b/packages/tauri-plugin/src/lib.rs
@@ -57,7 +57,11 @@ fn authority_from_host_port(host: &str, port: Option<u16>) -> String {
 }
 
 fn windows_remote_path(uri: &Uri) -> Option<(String, Option<u16>, String)> {
-    if uri.host() != Some("module-federation.localhost") {
+    let host = uri.host()?;
+
+    let is_mf_host = host == "module-federation.localhost";
+    let is_webview2 = uri.scheme_str() == Some("module-federation") && host == "localhost";
+    if !is_mf_host && !is_webview2 {
         return None;
     }
 
@@ -89,7 +93,6 @@ fn resolve_remote_url(uri: &Uri, schemes: &Schemes) -> Url {
             query_pairs.get("fullUrl").map(|v| {
                 let url = Url::parse(v).unwrap();
                 let mut schemes = schemes.0.lock().unwrap();
-
                 schemes
                     .entry(remote_key(&url))
                     .or_insert(url.scheme().to_string());
@@ -107,15 +110,19 @@ fn resolve_remote_url(uri: &Uri, schemes: &Schemes) -> Url {
                         .unwrap_or_else(|| "/".to_string()),
                 )
             });
-
             let schemes = schemes.0.lock().unwrap();
-            let scheme = schemes.get(&(host.clone(), port)).unwrap_or_else(|| {
-                dbg!(&schemes);
-                panic!("Unknown scheme for host '{host}:{port:?}'")
-            });
-
+            let scheme = schemes
+                .get(&(host.clone(), port))
+                .map(String::as_str)
+                .unwrap_or_else(|| {
+                    if uri.scheme_str() == Some("module-federation") {
+                        "http"
+                    } else {
+                        "https"
+                    }
+                });
             let builder = uri::Builder::new()
-                .scheme(scheme.as_str())
+                .scheme(scheme)
                 .authority(authority_from_host_port(&host, port))
                 .path_and_query(path_and_query);
 
@@ -140,11 +147,9 @@ pub fn init<R: Runtime>(arg: Option<&'static str>) -> TauriPlugin<R> {
                 std::fs::create_dir_all(&cache_dir).unwrap();
 
                 let app = app.app_handle().clone();
-                app.manage(Schemes::default());
 
                 tauri::async_runtime::spawn(async move {
                     let schemes = app.state::<Schemes>();
-
                     let client = reqwest::Client::new();
                     let url = request.uri().clone();
                     let url = resolve_remote_url(&url, schemes.inner());
@@ -231,6 +236,7 @@ pub fn init<R: Runtime>(arg: Option<&'static str>) -> TauriPlugin<R> {
             #[cfg(desktop)]
             let tauri_plugin_module_federation = desktop::init(app, api)?;
             app.manage(tauri_plugin_module_federation);
+            app.manage(Schemes::default());
 
             Ok(())
         })

--- a/packages/tauri/README.md
+++ b/packages/tauri/README.md
@@ -32,6 +32,7 @@ export default {
 ## Behavior
 
 - Hooks `afterResolve` and rewrites `remoteInfo.entry`.
+- Uses Tauri's `http://module-federation.localhost/...` custom-protocol URL shape on Windows and Android.
 - Registers a global runtime plugin during `beforeInit`.
 - Delegates fetching/caching to `tauri-plugin-module-federation`.
 

--- a/packages/tauri/index.js
+++ b/packages/tauri/index.js
@@ -1,15 +1,35 @@
 import { registerGlobalPlugins } from "@module-federation/runtime";
 
+const protocol = "module-federation";
+const windowsProtocolOrigin = `http://${protocol}.localhost`;
+
 /**
  * @typedef {Parameters<NonNullable<import("@module-federation/runtime").ModuleFederationRuntimePlugin["afterResolve"]>>[0]} LoadRemoteMatch
  */
+
+function usesWindowsProtocolOrigin() {
+	return typeof navigator !== "undefined" && /Windows|Android/i.test(navigator.userAgent);
+}
+
+/**
+ * @param {URL} url
+ */
+function createPluginUrl(url) {
+	const fullUrl = encodeURIComponent(url.href);
+
+	if (usesWindowsProtocolOrigin()) {
+		return `${windowsProtocolOrigin}/${url.host}${url.pathname}?fullUrl=${fullUrl}`;
+	}
+
+	return `${protocol}://${url.host}${url.pathname}?fullUrl=${fullUrl}`;
+}
 
 /**
     @param {LoadRemoteMatch} args
  */
 function afterResolve(args) {
 	const url = new URL(args.remoteInfo.entry);
-	args.remoteInfo.entry = `module-federation://${url.host}/?fullUrl=${url}`;
+	args.remoteInfo.entry = createPluginUrl(url);
 	return args;
 }
 


### PR DESCRIPTION
## Summary

- Emit Tauri's Windows/Android custom-protocol URL shape from `@module-federation/tauri`
- Resolve `http://module-federation.localhost/...` requests back to the real remote URL in the Rust plugin
- Add regression coverage for legacy custom-scheme URLs and Windows protocol URLs
- Document the platform-specific protocol behavior

## Root Cause

Tauri custom protocols do not use the same URL shape on every platform. macOS, iOS, and Linux can use `module-federation://...`, but Windows and Android route custom protocols through `http://<scheme>.localhost/...`.

The runtime package always emitted `module-federation://localhost:3002/...`, which can fail in Windows WebView2 before the Tauri protocol handler gets a usable request.

Fixes #20.

## Validation

- `cargo test --manifest-path packages/tauri-plugin/Cargo.toml`
- `pnpm --filter @module-federation/tauri build`
- `pnpm build`

Note: validated locally on macOS with unit coverage for the Windows URL form; this still needs confirmation on a Windows machine.
